### PR TITLE
Link to Lint typo

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,11 +27,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
-#    - name: Link with flake8
-#      run: |
-#        # stop the build if there are Python syntax errors or undefined names
-#        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-#        flake8 . --count --max-complexity=10 --max-line-length=127 --statistics
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 . --count --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with unittest 
       run: | 
         python -m unittest


### PR DESCRIPTION
I figured I typed "Link with flake8" when it really was supposed to be "Lint with flake8". I'm so sorry ppl!! I made everyone's life harder. Hopefully, this works now.